### PR TITLE
Do not run during design-time builds

### DIFF
--- a/SetLargeAddressAware/LargeAddressAware.targets
+++ b/SetLargeAddressAware/LargeAddressAware.targets
@@ -15,10 +15,12 @@
     </PropertyGroup>
     
     The target only runs after CoreCompile so it is incremental and does not need Inputs/Outputs
+    
+    Do not execute during design-time builds, because the output assembly won't exist yet even though CoreCompile has "run".
   -->
   <Target Name="SetLargeAddressAware"
           AfterTargets="CoreCompile"
-          Condition=" '$(LargeAddressAware)' == 'true' And Exists('$(LargeAddressAwareAssemblyFile)') And ('$(OutputType)' == 'Exe' Or '$(OutputType)' == 'Winexe') And '$(PlatformTarget)' == 'x86' ">
+          Condition=" ( '$(DesignTimeBuild)' != 'true' And '$(BuildingProject)' == 'true' ) And '$(LargeAddressAware)' == 'true' And Exists('$(LargeAddressAwareAssemblyFile)') And ('$(OutputType)' == 'Exe' Or '$(OutputType)' == 'Winexe') And '$(PlatformTarget)' == 'x86' ">
 
     <SetLargeAddressAware FilePath="@(IntermediateAssembly)" />
 

--- a/SetLargeAddressAware/SetLargeAddressAware.csproj
+++ b/SetLargeAddressAware/SetLargeAddressAware.csproj
@@ -6,7 +6,7 @@
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <BuildOutputTargetFolder>build</BuildOutputTargetFolder>
     <PackageId>LargeAddressAware</PackageId>
-    <Version>1.0.3</Version>
+    <Version>1.0.4</Version>
     <Authors>Kirill Osenkov</Authors>
     <Company>Kirill Osenkov</Company>
     <Description>Allows to mark an .exe post-compilation as LARGEADDRESSAWARE.


### PR DESCRIPTION
Fixes #7 by conditioning the target on "not design-time build". The condition is the inverse of the standard example given in    
https://github.com/dotnet/project-system/blob/master/docs/design-time-builds.md#determining-whether-a-target-is-running-in-a-design-time-build.