### PR TITLE
Drive AfterTargets via property to allow configuration

### DIFF
--- a/SetLargeAddressAware/LargeAddressAware.targets
+++ b/SetLargeAddressAware/LargeAddressAware.targets
@@ -6,6 +6,7 @@
       Full path to the assembly that contains the MSBuild task
     -->
     <LargeAddressAwareAssemblyFile Condition=" '$(LargeAddressAwareAssemblyFile)' == '' ">$(MSBuildThisFileDirectory)net46\SetLargeAddressAware.dll</LargeAddressAwareAssemblyFile>
+    <LargeAddressAwareAfterTargets Condition=" '$(LargeAddressAwareAfterTargets)' == '' ">CoreCompile</LargeAddressAwareAfterTargets>
   </PropertyGroup>
 
   <!--
@@ -19,7 +20,7 @@
     Do not execute during design-time builds, because the output assembly won't exist yet even though CoreCompile has "run".
   -->
   <Target Name="SetLargeAddressAware"
-          AfterTargets="CoreCompile"
+          AfterTargets="$(LargeAddressAwareAfterTargets)"
           Condition=" ( '$(DesignTimeBuild)' != 'true' And '$(BuildingProject)' == 'true' ) And '$(LargeAddressAware)' == 'true' And Exists('$(LargeAddressAwareAssemblyFile)') And ('$(OutputType)' == 'Exe' Or '$(OutputType)' == 'Winexe') And '$(PlatformTarget)' == 'x86' ">
 
     <SetLargeAddressAware FilePath="@(IntermediateAssembly)" />


### PR DESCRIPTION
This allows developers more control over when the target is ran. Definitely open to a better property name here if you've got a preference. =)

Related to conversations in #6. 